### PR TITLE
Fix: check only for dataSource

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -109,7 +109,7 @@ var dsQueryProvider = Fliplet.Widget.open('com.fliplet.data-source-query', {
 
 dsQueryProvider.then(function onForwardDsQueryProvider(result) {
   // If there is no data source just save it although not valid config
-  if (!dataSource || !dataSource.value) {
+  if (!dataSource) {
     Fliplet.Widget.save();
   }
 


### PR DESCRIPTION
dataSource is a var with the current selected datasource from the API. not a input field.