### PR TITLE
Default email and SMS verification code expiration set to 48 hours

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -142,3 +142,21 @@ body {
 .email-domains-input {
   margin-top: 10px;
 }
+
+select.custom-chevron {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -o-appearance: none;
+  appearance: none;
+  margin-left: -1px;
+}
+
+select.custom-chevron + i.fa {
+  float: right;
+  margin-top: -30px;
+  margin-right: 10px;
+  pointer-events: none;
+  background-color: transparent;
+  color: #abaaab;
+  padding-right: 5px;
+}

--- a/interface.html
+++ b/interface.html
@@ -4,11 +4,17 @@
     <div class="col-sm-4 control-label">
       <label for="expire-timeout">Verification code will expire after</label>
     </div>
-    <div class="col-sm-8">
-      <div class="input-group">
-        <input type="number" name="expire-timeout" class="form-control" id="expire-timeout" placeholder="Enter number of minutes" required />
-        <div class="input-group-addon">minutes</div>
-      </div>
+    <div class="col-xs-7 col-sm-5">
+      <input type="number" name="expire-timeout" class="form-control" id="expire-timeout" placeholder="Enter number of minutes" required />
+    </div>
+    <div class="col-xs-5 col-sm-3">
+      <select name="expire-timeout" id="time-value" class="form-control custom-chevron">
+        <option value="1">minutes</option>
+        <option value="60">hours</option>
+        <option value="1440">days</option>
+        <option value="10080">weeks</option>
+      </select>
+      <i class="fa fa-chevron-down"></i>
     </div>
   </div>
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -14,7 +14,9 @@ var defaultEmailSettings = {
 };
 
 var defaultSmsTemplate = 'Your code: {{ code }} (it will expire in {{ expire }} minutes)';
-var defaultExpireTimeout = 60;
+
+// Default expire timeout 2 days
+var defaultExpireTimeout = 2880;
 var dataSources;
 var dataSource;
 
@@ -43,7 +45,7 @@ function selectDataSource(ds) {
   var email = dataSource.definition && dataSource.definition.validation && dataSource.definition.validation.email || {};
   // SMS and email validations use the same expiration values
   // Therefore the value only needs to be restored from the SMS configuration
-  $('#expire-timeout').val(sms.expire || email.expire || defaultExpireTimeout);
+  setReadableExpirePeriod(sms.expire || email.expire || defaultExpireTimeout);
   $('#sms-template').val(sms.template || defaultSmsTemplate);
 
   if (email.domain) {
@@ -52,6 +54,39 @@ function selectDataSource(ds) {
   }
 
   Fliplet.Widget.autosize();
+}
+
+// Converts minutes to hours or days or weeks
+function setReadableExpirePeriod (value) {
+  var timeInterval = '1';
+
+  if (value % 60 === 0 && value > 0) {
+    // Converts to hours
+    value = value / 60;
+    timeInterval = '60';
+
+    if (value % 24 === 0) {
+      // Converts to days
+      value = value / 24;
+      timeInterval = '1440';
+
+      if (value % 7 === 0) {
+        // Converts to weeks
+        value = value / 7;
+        timeInterval = '10080';
+      }
+    }
+  }
+
+  $('#expire-timeout').val(value);
+  $('#time-value').val(timeInterval);
+}
+
+// Converts time to minutes depending on selected hours or days or weeks
+function convertTimeToMinutes () {
+  var inputValue = $('#expire-timeout').val();
+  var selectValue = $('#time-value').val();
+  return inputValue * selectValue;
 }
 
 var dsQueryData = {};
@@ -122,7 +157,7 @@ dsQueryProvider.then(function onForwardDsQueryProvider(result) {
         toColumn: result.data.columns.smsTo,
         matchColumn: result.data.columns.smsMatch,
         template: $('#sms-template').val(),
-        expire: $('#expire-timeout').val(),
+        expire: convertTimeToMinutes(),
       };
       break;
 
@@ -142,7 +177,7 @@ dsQueryProvider.then(function onForwardDsQueryProvider(result) {
         toColumn: result.data.columns.emailMatch,
         matchColumn: result.data.columns.emailMatch,
         template: emailProviderResult || defaultEmailSettings,
-        expire: $('#expire-timeout').val(),
+        expire: convertTimeToMinutes(),
         domain: domain,
         domains: domains
       }


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4774
## Description
Added functionality to change verification period by user to minutes, hours, days and weeks also send data in minutes to the backend
## Screenshots/screencasts
https://cl.ly/50c0ec267364
## Backward compatibility
This change is fully backward compatible.