### PR TITLE
Allow a user to save email subject after editing it

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -8,7 +8,7 @@ var $smsSettings = $('.sms-settings');
 
 var defaultEmailTemplate = $('#email-template-default').html();
 var defaultEmailSettings = {
-  subject: 'Validate your email address',
+  subject: 'Verify your email address',
   html: defaultEmailTemplate,
   to: []
 };
@@ -19,7 +19,6 @@ var dataSources;
 var dataSource;
 
 var emailProvider;
-var emailProviderResult;
 
 Fliplet.Widget.onSaveRequest(function() {
   if (!dataSource) {
@@ -101,7 +100,6 @@ var dsQueryProvider = Fliplet.Widget.open('com.fliplet.data-source-query', {
   onEvent: function(event, data) {
     if (event === 'data-source-changed') {
       selectDataSource(data);
-
       return true; // Stop propagation up to studio or parent components
     }
   }
@@ -141,7 +139,7 @@ dsQueryProvider.then(function onForwardDsQueryProvider(result) {
       validation.email = {
         toColumn: result.data.columns.emailMatch,
         matchColumn: result.data.columns.emailMatch,
-        template: emailProviderResult || defaultEmailSettings,
+        template: validation.email ? validation.email.template : defaultEmailSettings,
         expire: $('#expire-timeout').val(),
         domain: domain,
         domains: domains
@@ -166,7 +164,8 @@ dsQueryProvider.then(function onForwardDsQueryProvider(result) {
 
 // Click to edit email template should open email provider
 $('.show-email-provider').on('click', function() {
-  var emailProviderData = dataSource.definition && dataSource.definition.validation && dataSource.definition.validation.email && dataSource.definition.validation.email.template || defaultEmailSettings;
+  var emailProviderData = _.get(dataSource, 'definition.validation.email.template', defaultEmailSettings);
+
   emailProviderData.options = {
     usage: {
       code: 'Insert the verification code <strong>(Required)</strong>',
@@ -178,14 +177,28 @@ $('.show-email-provider').on('click', function() {
     hideBCC: true,
     hideCC: true
   };
+
   emailProvider = Fliplet.Widget.open('com.fliplet.email-provider', {
     data: emailProviderData
   });
 
+  Fliplet.Studio.emit('widget-save-label-update', {
+    text: 'Save'
+  });
+
   emailProvider.then(function onForwardEmailProvider(result) {
     emailProvider = null;
-    emailProviderResult = result.data;
+
+    var dataSourceTemplate = _.get(dataSource, 'definition.validation.email.template', false);
+
+    if (dataSourceTemplate) {
+      dataSource.definition.validation.email.template = result.data;
+    }
+
     Fliplet.Widget.autosize();
+    Fliplet.Studio.emit('widget-save-label-update', {
+      text: 'Save & Close'
+    });
   });
 });
 


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/3590

## Description
Allow a user to save email subject after editing it

## Screenshots/screencasts
![issue-3590](https://user-images.githubusercontent.com/53430352/69153082-44b9bb00-0ae6-11ea-98d7-b61e53a8d689.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
Remade this [PR](https://github.com/Fliplet/fliplet-widget-validation-manager/pull/9)