### PR TITLE
Prevent enter negative numbers in  expire input

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -5,7 +5,7 @@
       <label for="expire-timeout">Verification code will expire after</label>
     </div>
     <div class="col-xs-7 col-sm-5">
-      <input type="number" name="expire-timeout" class="form-control" id="expire-timeout" placeholder="Enter number of minutes" required />
+      <input type="number" name="expire-timeout" class="form-control" id="expire-timeout" placeholder="Enter a number" min="0" required />
     </div>
     <div class="col-xs-5 col-sm-3">
       <select name="expire-timeout" id="time-value" class="form-control custom-chevron">

--- a/js/interface.js
+++ b/js/interface.js
@@ -246,6 +246,11 @@ $('#email-domain').on('change', function() {
   Fliplet.Widget.autosize();
 });
 
+// Preveting entering invalid values in the expiration input
+$('#expire-timeout').on('keydown', function(event) {
+  return event.keyCode === 8 || /[0-9]+/.test(event.key);
+});
+
 // Initialize data.
 if (data.type === 'sms') {
   $smsSettings.removeClass('hidden');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4774

## Description
Only numbers and backspace are allowed.

## Screenshots/screencasts
It works. Nothing to show)

## Backward compatibility
This change is fully backward compatible.