### PR TITLE
Restore expire date now works correcty

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -42,9 +42,13 @@ function selectDataSource(ds) {
 
   var sms = dataSource.definition && dataSource.definition.validation && dataSource.definition.validation.sms || {};
   var email = dataSource.definition && dataSource.definition.validation && dataSource.definition.validation.email || {};
-  // SMS and email validations use the same expiration values
-  // Therefore the value only needs to be restored from the SMS configuration
-  setReadableExpirePeriod(sms.expire || email.expire || defaultExpireTimeout);
+
+  if (data.type === 'email') {
+    setReadableExpirePeriod(email.expire || defaultExpireTimeout);
+  } else if (data.type === 'sms') {
+    setReadableExpirePeriod(sms.expire || defaultExpireTimeout);
+  }
+
   $('#sms-template').val(sms.template || defaultSmsTemplate);
 
   if (email.domain) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4774

## Description
Email expiration date was restored from SMS field. Now it is restored from the email field.

## Screenshots/screencasts
![valid-fix](https://user-images.githubusercontent.com/52824207/77319237-20c9e880-6d17-11ea-807a-eb369327fa63.gif)

## Backward compatibility
This change is fully backward compatible.