### PR TITLE
When a user press cancel button in email template he will close only email template, not all interface

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -22,6 +22,14 @@ var dataSource;
 
 var emailProvider;
 
+Fliplet.Widget.onCancelRequest(function() {
+  emailProvider.close();
+  emailProvider = null;
+
+  Fliplet.Widget.toggleCancelButton(true);
+  Fliplet.Widget.resetSaveButtonLabel();
+});
+
 Fliplet.Widget.onSaveRequest(function() {
   if (!dataSource) {
     return Fliplet.Widget.save({});
@@ -220,6 +228,8 @@ $('.show-email-provider').on('click', function() {
   emailProvider = Fliplet.Widget.open('com.fliplet.email-provider', {
     data: emailProviderData
   });
+
+  Fliplet.Widget.toggleCancelButton(false);
 
   Fliplet.Studio.emit('widget-save-label-update', {
     text: 'Save'


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6137

## Description
When a user press cancel button in email template he will close only email template, not all interface

## Screenshots/screencasts
https://share.getcloudapp.com/2NuBnZYZ

## Backward compatibility

This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 

## Notes
This is PR works alongside this [one](https://github.com/Fliplet/fliplet-widget-email-verification/pull/39).